### PR TITLE
Remove "discount" dependency

### DIFF
--- a/Formula/ikiwiki.rb
+++ b/Formula/ikiwiki.rb
@@ -58,7 +58,7 @@
 # Markdown (libmarkdown2 -- https://packages.debian.org/sid/libmarkdown2)
 # -- C library, "Discount is an implementation of John Gruber's Markdown
 #    markup language"
-# -- Provided by Homebrew "discount" package
+# -- Vendored by Text::Markdown::Discount
 #
 # Text::Markdown::Discount (libtext-markdown-discount-perl)
 # -- CPAN: https://metacpan.org/pod/Text::Markdown::Discount
@@ -96,7 +96,6 @@ class Ikiwiki < Formula
   license "GPL-2+"
 
   uses_from_macos "perl"
-  depends_on "discount"     # Markdown Parser
   depends_on "gettext"      # Translations
 
   resource "HTML::Scrubber" do


### PR DESCRIPTION
Ikiwiki uses Text::Markdown::Discount, which has vendored the discount C library.[1] Hence the discount dependency is not actually used.

1: https://github.com/sekimura/text-markdown-discount/tree/3f9e8175c1094144752c82271f5144f41e9c51c9/discount-2.2.7