### PR TITLE
Fix compilation error with newer Clang

### DIFF
--- a/Formula/ikiwiki.rb
+++ b/Formula/ikiwiki.rb
@@ -137,6 +137,7 @@ class Ikiwiki < Formula
 
     resource("Text::Markdown::Discount").stage do
       ohai "Installing resource Text::Markdown::Discount"
+      ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
       system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
       system "make"
       system "make", "install"


### PR DESCRIPTION
The discount version bundled with Text::Markdown::Discount (2.2.7) does not compile with newer versions of GCC or Clang due to a incompatible function pointer type.

This commit disables the compiler check triggering the error, which is the same workaround as the official Homebrew "discount" package uses.[1]



1: https://github.com/Homebrew/homebrew-core/commit/ee1d5aee9fdc9093c5c4720d26cef5987928104f